### PR TITLE
Update options usage syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,19 @@ Following command, Output fiile name would be `ilib-translation.js`
 ```
 resbundler.js --assembly=assembled --compilation=compiled --resDir=resources --outDir=result
 ```
+or
+```
+resbundler.js -a assembled -c compiled -r resources --o result
+```
 
 2. Generate `js` files per locale.   
 Following command, Output file would be `ko-KR.js, es-ES.js`
 ```
 resbundler.js --assembly=dynamic --compiled=compiled --resDir=resources --outDir=result --locales=ko-KR,es-ES
+```
+or
+```
+resbundler.js -a dynamic -c compiled -r resources -o result -l ko-KR,es-ES
 ```
 
 Release Notes

--- a/README.md
+++ b/README.md
@@ -20,17 +20,20 @@ Usage
 1. Include all data in one `js` file.   
 Following command, Output fiile name would be `ilib-translation.js`
 ```
-resbundler.js --assembly assembled --compiled compiled --resDir resources --outDir result
+resbundler.js --assembly=assembled --compilation=compiled --resDir=resources --outDir=result
 ```
 
 2. Generate `js` files per locale.   
 Following command, Output file would be `ko-KR.js, es-ES.js`
 ```
-resbundler.js --assembly dynamic --compiled compiled --resDir resources --outDir result --locales "ko-KR,es-ES"
+resbundler.js --assembly=dynamic --compiled=compiled --resDir=resources --outDir=result --locales=ko-KR,es-ES
 ```
 
 Release Notes
 -------------
+### 1.1.0
+Update option usage
+
 ### 1.0.1
 Update to add excutable `resbundler` file that would install into the PATH
 

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "ilib-resbundler",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "convert JSON type of resources to JS files",
   "main": "resbundler.js",
-  "bin":{
+  "bin": {
     "ilib-resbundler": "./resbundler.js"
   },
   "scripts": {
     "dist": "npm publish",
     "test-clean": "rm -rf test/result",
-    "test-assemble": "cd test;../resbundler.js -o result",
-    "test-dynamic": "cd test;../resbundler.js -a dynamic -o result -l 'ko-KR,es-ES,zh-Hans-CN'"
+    "test-assemble": "cd test;../resbundler.js --outDir=result",
+    "test-dynamic": "cd test;../resbundler.js --assembly=dynamic --outDir=result --locales=ko-KR,es-ES,zh-Hans-CN"
   },
   "repository": {
     "type": "git",
@@ -33,5 +33,8 @@
   "dependencies": {
     "ilib-common": "^1.0.1",
     "uglify-js": "^3.14.5"
+  },
+  "devDependencies": {
+    "options-parser": "^0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,9 +32,7 @@
   "homepage": "https://github.com/iLib-js/ilib-resbundler#readme",
   "dependencies": {
     "ilib-common": "^1.0.1",
-    "uglify-js": "^3.14.5"
-  },
-  "devDependencies": {
+    "uglify-js": "^3.14.5",
     "options-parser": "^0.4.0"
   }
 }

--- a/resbundler.js
+++ b/resbundler.js
@@ -35,6 +35,12 @@ var defaultOptions = {
 var result = "";
 
 var optionConfig = {
+    help: {
+        short: "h",
+        showHelp: {
+            banner: 'Usage: ilib-resbundler [-h] [options] '
+        }
+    },
     assembly: {
         short: "a",
         "default": "assembled",

--- a/resbundler.js
+++ b/resbundler.js
@@ -34,40 +34,14 @@ var defaultOptions = {
 }
 var result = "";
 
-
-function usage() {
-    console.log("Usage: resbundler.js [-h] [-a assembly] [-c compilation] [-r resDir] [-o outDir] [-l locales]\n" +
-      "Convert json resource data to js file\n" +
-      "-h or --help\n" +
-      "  this help\n" +
-      "-a or --assembly\n" +
-      "  How you make the output. Valid values are 'assembled' and  'dynamic'. Default: 'assembled'.\n" +
-      "-c or --compilation\n" +
-      "  Whether you want the output to be compiled with uglify-js. Valid values are 'compiled', and 'uncompiled'. Default: 'compiled'.\n" +
-      "-r or --resDir\n" +
-      "  directory to read and file json files. Default: 'resources'\n" +
-      "-o or --outDir\n" +
-      "  directory to place output files. Default: current dir '.'\n" +
-      "-f or --filename\n" +
-      "  specify output file name when assembly mode is assembled. Default: 'ilib-translation.js'\n" +
-      "-l or --locales\n" +
-      "  Locales you want your make js files when assembely mode is `dynamic`. Value is a comma-separated list of BCP-47 style locale tags.");
-    process.exit();
-}
-
-var argv= process.argv;
-if (argv[2]== "--help" || argv[2]== "-h"){
-    usage();
-}
-
-var ignoreOutput = function(){};
-
 var optionConfig = {
     help: {
         short: "h",
         showHelp: {
             banner: 'Usage: ilib-resbundler [-h] [options] ',
-            output: ignoreOutput
+            output: function(msg){
+                console.log(msg);
+            }
         }
     },
     assembly: {

--- a/resbundler.js
+++ b/resbundler.js
@@ -21,30 +21,10 @@
 var fs = require("fs");
 var path = require("path");
 var uglifyjs = require('uglify-js');
+var OptionsParser = require("options-parser");
 var util =require("ilib-common").Utils;
 
-function usage() {
-    console.log("Usage: resbundler.js [-h] [-a assembly] [-c compiled] [-r resDir] [-o outDir] [-l locales]\n" +
-      "Convert json resource data to js file\n" +
-      "-h or --help\n" +
-      "  this help\n" +
-      "-a or --assembly\n" +
-      "  How you make the output. Valid values are 'assembled' and  'dynamic'. Default: 'assembled'.\n" +
-      "-c or --compiled\n" +
-      "  Whether you want the output to be compiled with uglify-js. Valid values are 'compiled', and 'uncompiled'. Default: 'compiled'.\n" +
-      "-r or --resDir\n" +
-      "  directory to read and file json files. Default: 'resources'\n" +
-      "-o or --outDir\n" +
-      "  directory to place output files. Default: current dir '.'\n" +
-      "-f or --filename\n" +
-      "  specify output file name when assembly mode is assembled. Default: 'ilib-translation.js'\n" +
-      "-l or --locales\n" +
-      "  Locales you want your make js files when assembely mode is `dynamic`. Value is a comma-separated list of BCP-47 style locale tags.");
-    process.exit();
-}
-
-var argv = process.argv;
-var options = {
+var defaultOptions = {
     assembly: "assembled",
     compiled: "compiled",
     resDir: "resources",
@@ -54,29 +34,52 @@ var options = {
 }
 var result = "";
 
-for (var i = 0; i < argv.length; i++){
-    var val = argv[i];
-    if (val === "-h" || val == "--help"){
-        usage();
-    } else if (val === "-a" || val === "--assembly"){
-        options.assembly = argv[++i];
-    } else if(val === "-c" || val === "--compiled"){
-        options.compiled = argv[++i];
-    } else if (val === "-r" || val === "--resDir"){
-        options.resDir = argv[++i];
-    } else if (val === "-o" || val === "--outDir"){
-        options.outDir = argv[++i];
-        if (!fs.existsSync(options.outDir)){
-            fs.mkdirSync(options.outDir);
-        }
-    } else if (val === "-f" || val === "--filename"){
-        options.filename = argv[++i];
-    } else if (val === "-l" || val === "--locales"){
-        if (i < argv.length && argv[i+1]) {
-            options.locales = argv[++i].split(",");
-        }
+var optionConfig = {
+    assembly: {
+        short: "a",
+        "default": "assembled",
+        help: "How you make the output. Valid values are 'assembled' and  'dynamic'. Default: 'assembled'."
+    },
+    compilation: {
+        short: "c",
+        "default": "compiled",
+        help: "Whether you want the output to be compiled with uglify-js. Valid values are 'compiled', and 'uncompiled'. Default: 'compiled'."
+    },
+    resDir: {
+        short: "r",
+        "default": "resources",
+        help: "directory to read and file json files. Default: 'resources'"
+    },
+    outDir: {
+        short: "o",
+        "default": ".",
+        help: "directory to place output files. Default: current dir '.'"
+    },
+    outFileName: {
+        short: "r",
+        "default": "ilib-translation.js",
+        help: "specify output file name when assembly mode is assembled. Default: 'ilib-translation.js'"
+    },
+    locales: {
+        short: "l",
+        "default": "",
+        help: "Locales you want your make js files when assembely mode is `dynamic`. Value is a comma-separated list of BCP-47 style locale tags."
     }
 }
+
+var options = OptionsParser.parse(optionConfig);
+
+var assembly = options.opt.assembly || defaultOptions.assembly;
+var compilation = options.opt.compilation || defaultOptions.compilation;
+var resDir = options.opt.resDir || defaultOptions.resDir;
+var outDir = options.opt.outDir || defaultOptions.outDir;
+if (outDir && !fs.existsSync(outDir)){
+    fs.mkdirSync(outDir);
+};
+var outFileName = options.opt.outFileName || defaultOptions.filename;
+
+var locales = typeof(options.opt.locales) === "string" ? options.opt.locales.split(",") : defaultOptions.locales;
+
 
 function manipulateKey(fullPath){
     if (!fullPath) return;
@@ -110,15 +113,15 @@ function assembleFiles(dir){
 }
 
 function dynamicFiles(){
-    if ((options.assembly != "assembled" || options.assembly == "dynamic")){
-        if (options.locales.length > 0) {
-            options.locales.forEach(function(lo){
+    if ((assembly != "assembled" || assembly == "dynamic")){
+        if (locales.length > 0) {
+            locales.forEach(function(lo){
                 result = "";
                 var loList = util.getLocFiles(lo, "strings.json").filter(function(item){
                     return (item.indexOf("und") == -1)
                 });
                 loList.map(function(current, index, arr){
-                    var respath = path.join(options.resDir, arr[index]);
+                    var respath = path.join(resDir, arr[index]);
                     if (fs.existsSync(respath)){
                         var data = fs.readFileSync(respath, "utf-8");
                         var dataKey = manipulateKey(respath);
@@ -128,8 +131,8 @@ function dynamicFiles(){
                         }
                     }
                 });
-                var filename = lo + ".js";
-                writeFiles(result, filename);
+                var file = lo + ".js";
+                writeFiles(result, file);
             });
         } else {
             console.log("ERROR: Locale list are missing.");
@@ -138,19 +141,19 @@ function dynamicFiles(){
     }
 }
 
-function writeFiles(writeData, filename){
-    var writeName = filename || options.filename
-    if (options.compiled == "compiled") {
+function writeFiles(writeData, file){
+    var writeName = file || outFileName;
+    if (compilation == "compiled") {
         var minifyResult = uglifyjs.minify(writeData);
-        fs.writeFileSync(path.join(options.outDir, writeName), minifyResult.code, 'utf-8');
+        fs.writeFileSync(path.join(outDir, writeName), minifyResult.code, 'utf-8');
     } else {
-        fs.writeFileSync(path.join(options.outDir, writeName), writeData, 'utf-8');
+        fs.writeFileSync(path.join(outDir, writeName), writeData, 'utf-8');
     }
-    console.log("Generated [" + options.compiled + "] " + path.join(options.outDir, writeName) + " file.");
+    console.log("Generated [" + compilation + "] " + path.join(outDir, writeName) + " file.");
 }
 
-if(options.assembly == "assembled"){
-    var result = assembleFiles(options.resDir);
+if(assembly == "assembled"){
+    var result = assembleFiles(resDir);
     writeFiles(result);
 } else {
     dynamicFiles();

--- a/resbundler.js
+++ b/resbundler.js
@@ -34,17 +34,46 @@ var defaultOptions = {
 }
 var result = "";
 
+
+function usage() {
+    console.log("Usage: resbundler.js [-h] [-a assembly] [-c compilation] [-r resDir] [-o outDir] [-l locales]\n" +
+      "Convert json resource data to js file\n" +
+      "-h or --help\n" +
+      "  this help\n" +
+      "-a or --assembly\n" +
+      "  How you make the output. Valid values are 'assembled' and  'dynamic'. Default: 'assembled'.\n" +
+      "-c or --compilation\n" +
+      "  Whether you want the output to be compiled with uglify-js. Valid values are 'compiled', and 'uncompiled'. Default: 'compiled'.\n" +
+      "-r or --resDir\n" +
+      "  directory to read and file json files. Default: 'resources'\n" +
+      "-o or --outDir\n" +
+      "  directory to place output files. Default: current dir '.'\n" +
+      "-f or --filename\n" +
+      "  specify output file name when assembly mode is assembled. Default: 'ilib-translation.js'\n" +
+      "-l or --locales\n" +
+      "  Locales you want your make js files when assembely mode is `dynamic`. Value is a comma-separated list of BCP-47 style locale tags.");
+    process.exit();
+}
+
+var argv= process.argv;
+if (argv[2]== "--help" || argv[2]== "-h"){
+    usage();
+}
+
+var ignoreOutput = function(){};
+
 var optionConfig = {
     help: {
         short: "h",
         showHelp: {
-            banner: 'Usage: ilib-resbundler [-h] [options] '
+            banner: 'Usage: ilib-resbundler [-h] [options] ',
+            output: ignoreOutput
         }
     },
     assembly: {
         short: "a",
         "default": "assembled",
-        help: "How you make the output. Valid values are 'assembled' and  'dynamic'. Default: 'assembled'."
+        help: "How you make the output. Valid values are 'assembled' and  'dynamic'. Default: 'assembled'.",
     },
     compilation: {
         short: "c",
@@ -61,8 +90,8 @@ var optionConfig = {
         "default": ".",
         help: "directory to place output files. Default: current dir '.'"
     },
-    outFileName: {
-        short: "r",
+    filename: {
+        short: "f",
         "default": "ilib-translation.js",
         help: "specify output file name when assembly mode is assembled. Default: 'ilib-translation.js'"
     },
@@ -82,7 +111,7 @@ var outDir = options.opt.outDir || defaultOptions.outDir;
 if (outDir && !fs.existsSync(outDir)){
     fs.mkdirSync(outDir);
 };
-var outFileName = options.opt.outFileName || defaultOptions.filename;
+var outFileName = options.opt.filename || defaultOptions.filename;
 var locales = typeof(options.opt.locales) === "string" ? options.opt.locales.split(",") : defaultOptions.locales;
 
 function manipulateKey(fullPath){

--- a/resbundler.js
+++ b/resbundler.js
@@ -83,9 +83,7 @@ if (outDir && !fs.existsSync(outDir)){
     fs.mkdirSync(outDir);
 };
 var outFileName = options.opt.outFileName || defaultOptions.filename;
-
 var locales = typeof(options.opt.locales) === "string" ? options.opt.locales.split(",") : defaultOptions.locales;
-
 
 function manipulateKey(fullPath){
     if (!fullPath) return;


### PR DESCRIPTION
Updated options syntax to have same with `ilib-scanner` by using `options-parser`
Most `ilib-resbunder` use `ilib-scanner` at the same time. so I think it's better to have the same options syntax and name.